### PR TITLE
Remove tags that can be implied

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,16 @@
 <!doctype html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <meta name="description" content="">
-    <title>Minimal base.html</title>
-</head>
-<body>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="x-ua-compatible" content="ie=edge">
+<meta name="description" content="">
+<title>Minimal base.html</title>
 
-    <!-- Delete this part -->
-    <h1>base.html</h1>
-    <p>The absolute minimum <code>base.html</code> to get your project started.</p>
-    <h3>Usage:</h3>
-    <pre>
-      curl https://basehtml.xyz &gt; base.html
-    </pre>
-    <a href="https://github.com/sesh/base.html">more info</a>
-</body>
-</html>
+<!-- Delete this part -->
+<h1>base.html</h1>
+<p>The absolute minimum <code>base.html</code> to get your project started.</p>
+<h3>Usage:</h3>
+<pre>
+  curl https://basehtml.xyz &gt; base.html
+</pre>
+<a href="https://github.com/sesh/base.html">more info</a>


### PR DESCRIPTION
The tags `<html>`, `<body>` and `<head>` are implied when omitted. `<html>` is implied as the outermost tag if omitted, but we don't omit it because of the lang= attribute. `<head>` is implied as the first tag in `<html>`. `<body>` is implied by the first tag that does not fit in `<head>` (`<h1>` in this case). Closing tags are also implied at the end of the document.

Since this is a base html, it makes sense to omit tags that can be implied, because it means less boiler plate, and the resulting document is easier to read by humans. Additionally, by not using a `<body>` tag, we also shave off one layer of indentation.